### PR TITLE
Fix nil namespace error

### DIFF
--- a/lua/neotest-gtest/report.lua
+++ b/lua/neotest-gtest/report.lua
@@ -282,10 +282,10 @@ function ReportConverter:_collect_missing_nodes(results)
   local namespaces = {}
   for node_id, _ in pairs(results) do
     if node_id ~= nil then
-        local namespace = extract_namespace(node_id)
-        if namespace ~= nil then
-            namespaces[extract_namespace(node_id)] = true
-        end
+      local namespace = extract_namespace(node_id)
+      if namespace ~= nil then
+        namespaces[extract_namespace(node_id)] = true
+      end
     end
   end
 
@@ -300,7 +300,6 @@ function ReportConverter:_collect_missing_nodes(results)
     end
   end
   return missing
-
 end
 
 ---@private

--- a/lua/neotest-gtest/report.lua
+++ b/lua/neotest-gtest/report.lua
@@ -281,7 +281,12 @@ function ReportConverter:_collect_missing_nodes(results)
   local missing = {}
   local namespaces = {}
   for node_id, _ in pairs(results) do
-    namespaces[extract_namespace(node_id)] = true
+    if node_id ~= nil then
+        local namespace = extract_namespace(node_id)
+        if namespace ~= nil then
+            namespaces[extract_namespace(node_id)] = true
+        end
+    end
   end
 
   for name, fpath in pairs(self._spec.context.name2path) do
@@ -295,6 +300,7 @@ function ReportConverter:_collect_missing_nodes(results)
     end
   end
   return missing
+
 end
 
 ---@private


### PR DESCRIPTION
Error will be reported if the extracted namespace is nil. We should skip the operation if it's nil