### PR TITLE
fix(nvim-treesitter): Use upstream get_lang func

### DIFF
--- a/lua/neotest-gtest/parse.lua
+++ b/lua/neotest-gtest/parse.lua
@@ -185,7 +185,7 @@ end
 
 local function get_file_language(file_path)
   local ft = files.detect_filetype(file_path)
-  return require("nvim-treesitter.parsers").ft_to_lang(ft)
+  return vim.treesitter.language.get_lang(ft)
 end
 
 local function parser_get_tree(lang_tree)


### PR DESCRIPTION
nvim-treesitter main branch no longer has functions such as require("nvim-treesitter.parsers").ft_to_lang(). using upstream equivalent vim.treesitter.language.get_lang instead