### PR TITLE
feat: auto-detect test executables via CMake Tools

### DIFF
--- a/lua/neotest-gtest/executables/registry.lua
+++ b/lua/neotest-gtest/executables/registry.lua
@@ -1,4 +1,5 @@
 local Storage = require("neotest-gtest.storage")
+local config = require("neotest-gtest.config")
 local utils = require("neotest-gtest.utils")
 local lib = require("neotest.lib")
 local neotest = require("neotest")
@@ -65,7 +66,9 @@ end
 function ExecutablesRegistry:find_executables(id)
   self:_reload_tree()
   self:_ensure_node_within_root(id)
-  local exe = self._node2executable[id] or self:_lookup_ancestor_executable(id)
+  local exe = self._node2executable[id]
+    or self:_lookup_ancestor_executable(id)
+    or self:_lookup_cmake_executable(id)
   if exe ~= nil then
     return { [exe] = { id } }, nil
   end
@@ -87,6 +90,37 @@ function ExecutablesRegistry:_lookup_ancestor_executable(id)
     local exe = self._node2executable[ancestor]
     if exe ~= nil then
       return exe
+    end
+  end
+end
+
+
+-- Adapted from: https://github.com/alfaix/neotest-gtest/issues/12
+-- Original authors: ll-nick, AbaoFromCUG
+function ExecutablesRegistry:_lookup_cmake_executable(id)
+  local success, cmake_tools = pcall(require, "cmake-tools")
+  if not success then
+    return
+  end
+  local ancestors
+  if id:match("%.cpp$") then
+    ancestors = { id }
+  else
+    ancestors = utils.collect_iterable(self:_iter_ancestors(id))
+  end
+  local ancestors_set = utils.list_to_set(ancestors)
+  local build_dir = utils.normalize_path(tostring(cmake_tools.get_build_directory()))
+  local model_info = cmake_tools.get_model_info()
+  for _, target_info in pairs(model_info) do
+    if target_info.type == "EXECUTABLE" then
+      local executable_path_relative = target_info.artifacts[1].path
+      for _, source in ipairs(target_info.sources) do
+        local source_path = utils.normalize_path(source.path)
+        if ancestors_set[source_path] then
+          local executable_path = build_dir .. lib.files.sep .. executable_path_relative
+          return executable_path
+        end
+      end
     end
   end
 end

--- a/tests/unit/executables_spec.lua
+++ b/tests/unit/executables_spec.lua
@@ -222,4 +222,112 @@ describe("test global registry", function()
 
     assert.are.same({ "/bin/exe1", "/bin/exe2" }, exes)
   end)
+
+  it("CMake lookup by test", function()
+    local cmakeRegistry = ExecutablesRegistry:new("/tmp")
+    local node_id = "/tmp/project/test.cpp::testFixture::test"
+    package.loaded["cmake-tools"] = {
+      get_build_directory = function()
+        return "/tmp/project/build"
+      end,
+      get_model_info = function()
+        return {
+          {
+            type = "EXECUTABLE",
+            artifacts = {
+              { path = "test" },
+            },
+            sources = {
+              {
+                path = "/tmp/project/test.cpp",
+              },
+            },
+          },
+        }
+      end,
+    }
+    local executable = cmakeRegistry:_lookup_cmake_executable(node_id)
+    assert.are.equal("/tmp/project/build/test", executable)
+  end)
+
+  it("CMake lookup by file", function()
+    local cmakeRegistry = ExecutablesRegistry:new("/tmp")
+    local node_id = "/tmp/project/test.cpp"
+    package.loaded["cmake-tools"] = {
+      get_build_directory = function()
+        return "/tmp/project/build"
+      end,
+      get_model_info = function()
+        return {
+          {
+            type = "EXECUTABLE",
+            artifacts = {
+              { path = "test" },
+            },
+            sources = {
+              {
+                path = "/tmp/project/test.cpp",
+              },
+            },
+          },
+        }
+      end,
+    }
+    local executable = cmakeRegistry:_lookup_cmake_executable(node_id)
+    assert.are.equal("/tmp/project/build/test", executable)
+  end)
+
+  it("CMake lookup by fixture", function()
+    local registry = ExecutablesRegistry:new("/tmp")
+    local node_id = "/tmp/project/test.cpp::testFixture"
+    package.loaded["cmake-tools"] = {
+      get_build_directory = function()
+        return "/tmp/project/build"
+      end,
+      get_model_info = function()
+        return {
+          {
+            type = "EXECUTABLE",
+            artifacts = {
+              { path = "test" },
+            },
+            sources = {
+              {
+                path = "/tmp/project/test.cpp",
+              },
+            },
+          },
+        }
+      end,
+    }
+    local executable = registry:_lookup_cmake_executable(node_id)
+    assert.are.equal("/tmp/project/build/test", executable)
+  end)
+
+  it("CMake lookup fail", function()
+    local cmakeRegistry = ExecutablesRegistry:new("/tmp")
+    local node_id = "/tmp/project/notfound.cpp::testFixture::test"
+    package.loaded["cmake-tools"] = {
+      get_build_directory = function()
+        return "/tmp/project/build"
+      end,
+      get_model_info = function()
+        return {
+          {
+            type = "EXECUTABLE",
+            artifacts = {
+              { path = "test" },
+            },
+            sources = {
+              {
+                path = "/tmp/project/test.cpp",
+              },
+            },
+          },
+        }
+      end,
+    }
+    local executable = cmakeRegistry:_lookup_cmake_executable(node_id)
+    assert.are.equal(nil, executable)
+  end)
 end)


### PR DESCRIPTION
Adds automatic detection of Google Test executables via [CMake Tools](https://github.com/Civitasv/cmake-tools.nvim). This is largely based on the discussions in issue #12. The submitted patch sort of worked but required a few tweaks. Permission to use the patch was granted, and credit will be given to the original authors in the form of a code comment. I also added a couple of tests. Feature has some imperfections, which I consider out of scope.

**Working**
- Automatic test executable discovery for a file
- Automatic test executable discovery for a test fixture
- Automatic test executable discovery for a test

**Known issues**
- Does not automatically discover executables for a directory
- Issues may arise if the current working directory is not in the project root

I omitted implementation for directory-based discovery, as neotest-gtest seems to assume that a directory maps to a single test executable, which is not always the case. cmake-tools expects the current working directory to be in the project root, so fixing such issues would quickly snowball.

closes #12